### PR TITLE
Fixes lua error in for outlaw rogue

### DIFF
--- a/MaxDps_Rogue/main.lua
+++ b/MaxDps_Rogue/main.lua
@@ -185,7 +185,7 @@ function MaxDps.Rogue.Outlaw()
         return _MarkedforDeath;
     end
     
-    if combo >= 5 and MaxDps:Aura(_GreenskinsWaterloggedWristcuffs, timeShift) or and MaxDps:Aura(_MasterAssassinsInitiative, timeShift) then
+    if combo >= 5 and MaxDps:Aura(_GreenskinsWaterloggedWristcuffs, timeShift) and MaxDps:Aura(_MasterAssassinsInitiative, timeShift) then
         return _BetweentheEyes;
     end
 


### PR DESCRIPTION
I got this error:

```
Message: Interface\AddOns\MaxDps_Rogue\main.lua:188: unexpected symbol near 'and'
Time: 06/16/18 08:28:02
Count: 1
Stack: Interface\AddOns\MaxDps_Rogue\main.lua:188: unexpected symbol near 'and'
[C]: ?
[C]: ?
[C]: in function `LoadAddOn'
Interface\AddOns\MaxDps\core.lua:466: in function `LoadModule'
Interface\AddOns\MaxDps\core.lua:441: in function `InitRotations'
Interface\AddOns\MaxDps\core.lua:382: in function `?'
...sic\Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua:145: in function <...sic\Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua:145>
[string "safecall Dispatcher[1]"]:4: in function <[string "safecall Dispatcher[1]"]:4>
[C]: ?
[string "safecall Dispatcher[1]"]:13: in function `?'
...sic\Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua:90: in function `Fire'
...ccountant_Classic\Libs\AceEvent-3.0\AceEvent-3.0.lua:120: in function <...ccountant_Classic\Libs\AceEvent-3.0\AceEvent-3.0.lua:119>
```

So I fixed it. I belive it is meant to be an "and" in there.